### PR TITLE
chore(deps): revert "chore(deps): update dependency conventional-changelog-conventionalcommits to v10"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
           semantic_version: 25.0.9
           dry_run: ${{ github.event_name == 'pull_request' }}
           extra_plugins: |
-            conventional-changelog-conventionalcommits@10.3.0
+            conventional-changelog-conventionalcommits@9.3.1
             @semantic-release/changelog@7.0.0
             @semantic-release/exec@7.1.0
             @semantic-release/git@11.0.1


### PR DESCRIPTION
Reverts #973 due to [semantic-release/commit-analyzer#921](https://github.com/semantic-release/commit-analyzer/issues/921)